### PR TITLE
registry: retryable discovery requests

### DIFF
--- a/internal/initwd/module_install.go
+++ b/internal/initwd/module_install.go
@@ -438,8 +438,8 @@ func (i *ModuleInstaller) installRegistryModule(req *earlyconfig.ModuleRequest, 
 			log.Printf("[ERROR] %s from %s %s: %s", key, addr, latestMatch, err)
 			diags = diags.Append(tfdiags.Sourceless(
 				tfdiags.Error,
-				"Invalid response from remote module registry",
-				fmt.Sprintf("The remote registry at %s failed to return a download URL for %s %s.", hostname, addr, latestMatch),
+				"Error accessing remote module registry",
+				fmt.Sprintf("Failed to retrieve a download URL for %s %s from %s: %s", addr, latestMatch, hostname, err),
 			))
 			return nil, nil, diags
 		}

--- a/registry/client.go
+++ b/registry/client.go
@@ -368,6 +368,8 @@ func (c *Client) TerraformProviderLocation(provider *regsrc.TerraformProvider, v
 	return &loc, nil
 }
 
+// configureDiscoveryRetry configures the number of retries the registry client
+// will attempt for requests with retryable errors, like 502 status codes
 func configureDiscoveryRetry() {
 	discoveryRetry = defaultRetry
 

--- a/registry/client.go
+++ b/registry/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-svchost"
 	"github.com/hashicorp/terraform-svchost/disco"
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/httpclient"
 	"github.com/hashicorp/terraform/registry/regsrc"
 	"github.com/hashicorp/terraform/registry/response"
@@ -73,6 +74,13 @@ func NewClient(services *disco.Disco, client *http.Client) *Client {
 	retryableClient.RetryMax = discoveryRetry
 	retryableClient.RequestLogHook = requestLogHook
 	retryableClient.ErrorHandler = maxRetryErrorHandler
+
+	logOutput, err := logging.LogOutput()
+	if err != nil {
+		log.Printf("[WARN] Failed to set up registry client logger, "+
+			"continuing without client logging: %s", err)
+	}
+	retryableClient.Logger = log.New(logOutput, "", log.Flags())
 
 	services.Transport = retryableClient.HTTPClient.Transport
 

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -30,11 +30,10 @@ func TestConfigureDiscoveryRetry(t *testing.T) {
 	})
 
 	t.Run("configured retry", func(t *testing.T) {
-		defer func() {
-			os.Setenv(registryDiscoveryRetryEnvName,
-				os.Getenv(registryDiscoveryRetryEnvName))
+		defer func(retryEnv string) {
+			os.Setenv(registryDiscoveryRetryEnvName, retryEnv)
 			discoveryRetry = defaultRetry
-		}()
+		}(os.Getenv(registryDiscoveryRetryEnvName))
 		os.Setenv(registryDiscoveryRetryEnvName, "2")
 
 		configureDiscoveryRetry()

--- a/registry/client_test.go
+++ b/registry/client_test.go
@@ -1,7 +1,9 @@
 package registry
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -13,6 +15,42 @@ import (
 	"github.com/hashicorp/terraform/registry/test"
 	tfversion "github.com/hashicorp/terraform/version"
 )
+
+func TestConfigureDiscoveryRetry(t *testing.T) {
+	t.Run("default retry", func(t *testing.T) {
+		if discoveryRetry != defaultRetry {
+			t.Fatalf("expected retry %q, got %q", defaultRetry, discoveryRetry)
+		}
+
+		rc := NewClient(nil, nil)
+		if rc.client.RetryMax != defaultRetry {
+			t.Fatalf("expected client retry %q, got %q",
+				defaultRetry, rc.client.RetryMax)
+		}
+	})
+
+	t.Run("configured retry", func(t *testing.T) {
+		defer func() {
+			os.Setenv(registryDiscoveryRetryEnvName,
+				os.Getenv(registryDiscoveryRetryEnvName))
+			discoveryRetry = defaultRetry
+		}()
+		os.Setenv(registryDiscoveryRetryEnvName, "2")
+
+		configureDiscoveryRetry()
+		expected := 2
+		if discoveryRetry != expected {
+			t.Fatalf("expected retry %q, got %q",
+				expected, discoveryRetry)
+		}
+
+		rc := NewClient(nil, nil)
+		if rc.client.RetryMax != expected {
+			t.Fatalf("expected client retry %q, got %q",
+				expected, rc.client.RetryMax)
+		}
+	})
+}
 
 func TestLookupModuleVersions(t *testing.T) {
 	server := test.Registry()
@@ -179,18 +217,29 @@ func TestAccLookupModuleVersions(t *testing.T) {
 	}
 }
 
-// the error should reference the config source exatly, not the discovered path.
+// the error should reference the config source exactly, not the discovered path.
 func TestLookupLookupModuleError(t *testing.T) {
 	server := test.Registry()
 	defer server.Close()
 
 	client := NewClient(test.Disco(server), nil)
 
-	// this should not be found in teh registry
+	// this should not be found in the registry
 	src := "bad/local/path"
 	mod, err := regsrc.ParseModuleSource(src)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// Instrument CheckRetry to make sure 404s are not retried
+	retries := 0
+	oldCheck := client.client.CheckRetry
+	client.client.CheckRetry = func(ctx context.Context, resp *http.Response, err error) (bool, error) {
+		if retries > 0 {
+			t.Fatal("retried after module not found")
+		}
+		retries++
+		return oldCheck(ctx, resp, err)
 	}
 
 	_, err = client.ModuleLocation(mod, "0.2.0")
@@ -201,6 +250,31 @@ func TestLookupLookupModuleError(t *testing.T) {
 	// check for the exact quoted string to ensure we didn't prepend a hostname.
 	if !strings.Contains(err.Error(), `"bad/local/path"`) {
 		t.Fatal("error should not include the hostname. got:", err)
+	}
+}
+
+func TestLookupModuleRetryError(t *testing.T) {
+	server := test.RegistryRetryableErrorsServer()
+	defer server.Close()
+
+	client := NewClient(test.Disco(server), nil)
+
+	src := "example.com/test-versions/name/provider"
+	modsrc, err := regsrc.ParseModuleSource(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := client.ModuleVersions(modsrc)
+	if err == nil {
+		t.Fatal("expected requests to exceed retry", err)
+	}
+	if resp != nil {
+		t.Fatal("unexpected response", *resp)
+	}
+
+	// verify maxRetryErrorHandler handler returned the error
+	if !strings.Contains(err.Error(), "the request failed after 2 attempts, please try again later") {
+		t.Fatal("unexpected error, got:", err)
 	}
 }
 

--- a/registry/test/mock_registry.go
+++ b/registry/test/mock_registry.go
@@ -363,3 +363,16 @@ func mockRegHandler() http.Handler {
 func Registry() *httptest.Server {
 	return httptest.NewServer(mockRegHandler())
 }
+
+// RegistryRetryableErrorsServer returns an httptest server that mocks out the
+// registry API to return 502 errors.
+func RegistryRetryableErrorsServer() *httptest.Server {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/modules/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "mocked server error", http.StatusBadGateway)
+	})
+	mux.HandleFunc("/v1/providers/", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "mocked server error", http.StatusBadGateway)
+	})
+	return httptest.NewServer(mux)
+}

--- a/website/docs/commands/environment-variables.html.md
+++ b/website/docs/commands/environment-variables.html.md
@@ -114,6 +114,12 @@ exact output differences can change between minor Terraform versions.
 
 For more details see [Running Terraform in Automation](https://learn.hashicorp.com/terraform/development/running-terraform-in-automation).
 
+## TF_REGISTRY_DISCOVERY_RETRY
+
+Set `TF_REGISTRY_DISCOVERY_RETRY` to configure the max number of request retries
+the remote registry client will attempt for client connection errors or
+500-range responses that are safe to retry.
+
 ## TF_CLI_CONFIG_FILE
 
 The location of the [Terraform CLI configuration file](/docs/commands/cli-config.html).


### PR DESCRIPTION
Adds retry request wrapping to the remote registry client during discovery for modules and providers. The default retry is 1 additional attempt for 500-range responses (except 501), and is configurable with the environment variable `TF_REGISTRY_DISCOVERY_RETRY`.

This PR adds logging for the retried attempts and also improves the error message when the requests fail for module downloads.

**Current error**
> **Error: Invalid response from remote module registry**
>
> The remote registry at app.terraform.io failed to return a download URL for app.terraform.io/namespace/module/provider 0.1.0.

**New error** is now uniform between download and list versions requests
> **Error accessing remote module registry**
>
> Failed to retrieve a download URL for app.terraform.io/namespace/module/provider 0.1.0 from app.terraform.io: the request failed after 2 attempts, please try again later: 502 net/http: request canceled (Client.Timeout exceeded while awaiting headers).

The retry attempts msg in the error is included for both module and provider discovery errors along with the status code and original error msg.

**Logging**
```
2020/02/18 12:30:55 [DEBUG] fetching module versions from "http://127.0.0.1:51466/v1/modules/test-versions/name/provider/versions"
2020/02/18 12:30:55 [DEBUG] GET http://127.0.0.1:51466/v1/modules/test-versions/name/provider/versions
2020/02/18 12:30:55 [TRACE] HTTP client GET request to http://127.0.0.1:51466/v1/modules/test-versions/name/provider/versions
2020/02/18 12:30:55 [DEBUG] GET http://127.0.0.1:51466/v1/modules/test-versions/name/provider/versions (status: 502): retrying in 1s (1 left)
2020/02/18 12:30:56 [INFO] Previous request to the remote registry failed, attempting retry.
2020/02/18 12:30:56 [TRACE] HTTP client GET request to http://127.0.0.1:51466/v1/modules/test-versions/name/provider/versions
```